### PR TITLE
making routes configurable

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2009-2013 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,15 @@ Generating a blog with `flipflop create` produces a `blog.json` file in your blo
 		}
 	},
 	"articles": "articles",
-	"domain": "http://yourdomain.com"
+	"domain": "http://yourdomain.com",
+	"routes": {
+		"archive": "/archive",
+		"article": "/:year/:month/:day/:slug",
+		"error": "/404.html",
+		"homepage": "/",
+		"feed": "/feed/rss.xml",
+		"tag": "/tag/:tag"
+	}
 }
 ```
 ###Options
@@ -77,6 +85,40 @@ Many of these properties are used within the blog's template files.
 +	`authors` key/value object containing article authors' information.  This is used to display information about an article's author on the associated article page.
 +	`articles` location of directory containing articles.  This defaults to a location relative to your blog's directory but can be absolute as well.
 +	`domain` used for creating absolute paths for your blog's feed
++	`routes` allow a user to configure the urls
+
+## Configuring Routes / Urls
+
+You can configure urls for yuor blog via the `routes` property in the `blog.json` config file.  For example, if you wanted to prefix your blog with **/blog/**, you can do the following:
+
+```javascript
+"routes": {
+	"archive": "/blog/archive",
+	"article": "/blog/:year/:month/:day/:slug",
+	"error": "/blog/404.html",
+	"homepage": "/blog",
+	"feed": "/blog/feed/rss.xml",
+	"tag": "/blog/tag/:tag"
+}
+```
+
+If **.html** extensions are what you live for, you could change your **article** route to look like:
+
+```javascript
+"article": "/:year/:month/:day/:slug.html"
+```
+
+There are a few special things to note with routes:
+
++ The **article** route requires a `:slug` param.  Available params are:
+	+ `:year`
+	+ `:month`
+	+ `:day`
+	+ `:slug` (required)
++ The **tag** route requires a `:tag` param.  Available params are:
+	+ `:tag` (required)
+
+---
 
 ##Write some articles
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ Not much to describe here, just a markdown formatted file containing your articl
 
 I'm happy to accomodate pull requests and bug reports, so fork it and improve it or [let me know if you find any issues][issues].
 
+## License
+
+(The MIT License)
+
+Copyright (c) 2013 Brad Harris
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 [GG]: http://www.urbandictionary.com/define.php?term=gg
 [markdown]: http://daringfireball.net/projects/markdown/
 [jade]: https://github.com/visionmedia/jade/

--- a/lib/article.api.js
+++ b/lib/article.api.js
@@ -1,8 +1,9 @@
-var path = require('path');
+var fs = require('fs'),
+	path = require('path');
 
-module.exports = (function() {
-
-	var sorted = [],
+module.exports = function(blog) {
+	var Article = require('./article')(blog),
+		sorted = [],
 		keyed = {},
 		tags = {};
 
@@ -16,12 +17,12 @@ module.exports = (function() {
 
 			if(!articlePath) return cb.call(this, new Error('must specify path of articles'));
 
-			require('fs').readdir(articlePath, function(err, files) {
+			fs.readdir(articlePath, function(err, files) {
 				if (err) return cb.call(self, err);
 
 				var article;
 				files.forEach(function(folder) {
-					article = require('./article.js').create(path.join(articlePath, folder));
+					article = Article.create(path.join(articlePath, folder));
 					if(article) sorted.push(article);
 				});
 
@@ -75,4 +76,4 @@ module.exports = (function() {
 
 	};
 
-})();
+};

--- a/lib/article.js
+++ b/lib/article.js
@@ -1,6 +1,7 @@
-var	path = require('path'),
+var	util = require('utile'),
 	fs = require('fs'),
-	util = require('utile'),
+	path = require('path'),
+	articlePath = require('./article.path'),
 	moment = require('moment'),
 	marked = require('marked').setOptions({
 		gfm: true,
@@ -9,64 +10,45 @@ var	path = require('path'),
 		highlight: function(code, lang) {
 			return require('highlight').Highlight(code);
 		}
-	}),
-	flipflop = require('./flipflop.js');
+	});
 
+module.exports = function(blog) {
 
-var Article = module.exports = function(config) {
-	var date = moment(Date.parse(config.date));
+	var Article = function(config) {
+		var date = moment(Date.parse(config.date));
 
-	this.author = config.author;
-	this.title = config.title;
-	this.slug = config.slug;
-	this.date = date;
-	this.formatted_date = date.format('dddd MMMM D, YYYY');
-	this.content = config.content;
-	this.publish = config.publish;
-	this.tags = config.tags;
-	this.path = date.format('/YYYY/MM/DD/')+config.slug+'/';
-};
-Article.prototype = {
+		this.author = config.author;
+		this.title = config.title;
+		this.slug = config.slug;
+		this.date = date;
+		this.formatted_date = date.format('dddd MMMM D, YYYY');
+		this.content = config.content;
+		this.publish = config.publish;
+		this.tags = config.tags;
+		this.path = articlePath(blog, this);
+	};
 
-	author : null,
+	Article.create = function(dir) {
+		var json = path.join(dir, 'article.json'),
+			md = path.join(dir, 'article.md'),
+			article,
+			config;
 
-	title : null,
+		if (fs.existsSync(json) && fs.existsSync(md)) {
+			//clone to avoid altering same instance
+			config = util.clone(require(json));
 
-	slug : null,
-
-	content : null,
-
-	date : null,
-
-	formatted_date : null,
-
-	publish : null,
-
-	tags : null,
-
-	path : null
-
-};
-Article.create = function(dir) {
-	var json = path.join(dir, 'article.json'),
-		md = path.join(dir, 'article.md'),
-		article,
-		config;
-
-	if (fs.existsSync(json) && fs.existsSync(md)) {
-		//clone to avoid altering same instance
-		config = util.clone(require(json));
-
-		if(config.publish) {
-			config.author = flipflop.authors[config.author];
-			config.slug = dir.split('/').pop();
-			config.content = marked(fs.readFileSync(md, 'utf8'));
-			article = new Article(config);
-		}else {
-			article = null;
+			if(config.publish) {
+				config.author = blog.authors[config.author];
+				config.slug = dir.split('/').pop();
+				config.content = marked(fs.readFileSync(md, 'utf8'));
+				article = new Article(config);
+			}else {
+				article = null;
+			}
 		}
-	}
-	return article;
-};
+		return article;
+	};
 
-module.exports = Article;
+	return Article;
+};

--- a/lib/article.path.js
+++ b/lib/article.path.js
@@ -1,0 +1,28 @@
+
+module.exports = function(blog, article) {
+	var path = Object.keys(mappings).reduce(function(path, curr) {
+		return path.replace(curr, mappings[curr](article));
+	}, blog.routes.article);
+
+	return path;
+};
+
+var mappings = {
+
+	':year': function(article) {
+		return article.date.format('YYYY');
+	},
+
+	':month': function(article) {
+		return article.date.format('MM');
+	},
+
+	':day': function(article) {
+		return article.date.format('DD');
+	},
+
+	':slug': function(article) {
+		return article.slug;
+	}
+
+};

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -72,7 +72,15 @@ cmd.lib = {
 			}
 		},
 		articles : 'articles',
-		domain : 'http://yourdomain.com'
+		domain : 'http://yourdomain.com',
+		routes: {
+			'archive': '/archive',
+			'article': '/:year/:month/:day/:slug',
+			'error': '/404.html',
+			'homepage': '/',
+			'feed': '/feed/rss.xml',
+			'tag': '/tag/:tag'
+		}
 	},
 
 	createBlog : function() {

--- a/lib/commands/gen.js
+++ b/lib/commands/gen.js
@@ -1,0 +1,1 @@
+module.exports = require('./generate');

--- a/lib/flipflop.js
+++ b/lib/flipflop.js
@@ -1,7 +1,109 @@
 var util = require('utile'),
 	crypto = require('crypto'),
+	winston = require('winston'),
+	wrench = require('wrench'),
 	fs = require('fs'),
-	path = require('path');
+	path = require('path'),
+	api = require('./article.api');
+
+function createBlog() {
+	var blog = {};
+	winston.cli().extend(blog);
+
+	blog.init = function(config) {
+		blog.dir = config.dir;
+		blog.title = config.title || 'icanhazaname?';
+		blog.description = config.description || 'ucanhazdescription';
+		blog.keywords = config.keywords || [];
+		blog.api = api(blog);
+		blog.authors = addGravatarHash(config.authors);
+		blog.domain = config.domain;
+		blog.routes = config.routes;
+		blog.plugins = [
+			require('./plugins/assets.js'),
+			require('./plugins/error.js'),
+			require('./plugins/homepage.js'),
+			require('./plugins/article.js'),
+			require('./plugins/archive.js'),
+			require('./plugins/feed.js'),
+			require('./plugins/tag.js')
+		];
+		return blog;
+	};
+
+	/**
+	 * Create and setup http server for serving blog dynamically
+	 */
+	blog.createApp = function(config) {
+		var express = require('express');
+
+		//defaults
+		config = util.mixin({
+			templates : blog.dir+'/theme/templates',
+			view_engine: 'jade',
+			view_options: { layout: false },
+			view_cache: false
+		}, (config||{}));
+
+		blog.app = express();
+
+		blog.app.configure(function(){
+			this.set('views', config.templates);
+			this.set('view engine', config.view_engine);
+			this.set('view options', config.view_options);
+			this.set('view cache', config.view_cache);
+			this.use(express.errorHandler({ showStack: true, dumpExceptions: true }));
+			this.use(express.bodyParser());
+			this.use(express.static(blog.dir+'/theme/static'));
+			this.use(this.router);
+		});
+
+		blog.plugins.forEach(function(plugin) {
+			if(plugin.register) plugin.register(blog);
+		});
+		return blog;
+	};
+
+	/**
+	 * Load article data into memory
+	 */
+	blog.load = function(articles, cb) {
+		blog.info('Loading articles');
+
+		blog.api.load(
+			articles.charAt(0) !== '/' ? path.join(blog.dir, articles) : articles,
+			cb.bind(blog)
+		);
+	};
+
+	/**
+	 * Create static version of blog in specified directory
+	 */
+	blog.generate = function(dir) {
+		blog.info('Generating:\t\t', dir);
+
+		if(fs.existsSync(dir)) {
+			wrench.rmdirSyncRecursive(dir);
+			blog.info('Removed directory:\t', dir);
+		}
+		fs.mkdirSync(dir);
+		blog.info('Created directory:\t', dir);
+		blog.plugins.forEach(function(plugin) {
+			plugin.generate(blog, dir);
+		});
+	};
+
+	/**
+	 * Pass-thru
+	 */
+	blog.listen = function(port) {
+		blog.app.listen(port);
+		blog.info("http server listening.", { port : port } );
+		return blog;
+	};
+
+	return blog;
+}
 
 function addGravatarHash(authors) {
 	for(var key in (authors||{})) {
@@ -12,112 +114,4 @@ function addGravatarHash(authors) {
 	return authors;
 }
 
-var Blog = function() {
-
-	this.dir = null;
-	this.title = null;
-	this.description = null;
-	this.keywords = null;
-	this.app = null;
-	this.api = null;
-	this.plugins = null;
-	this.authors = null;
-	this.domain = null;
-	this.log = null;
-
-	this.init = function(config) {
-		this.dir = config.dir;
-		this.title = config.title || 'icanhazaname?';
-		this.description = config.description || 'ucanhazdescription';
-		this.keywords = config.keywords || [];
-		require('winston').cli().extend(this);
-		this.api = require('./article.api.js');
-		this.authors = addGravatarHash(config.authors);
-		this.domain = config.domain;
-		this.plugins = [
-			require('./plugins/assets.js'),
-			require('./plugins/error.js'),
-			require('./plugins/homepage.js'),
-			require('./plugins/article.js'),
-			require('./plugins/archive.js'),
-			require('./plugins/feed.js'),
-			require('./plugins/tag.js')
-		];
-		return this;
-	};
-
-	/**
-	 * Create and setup http server for serving blog dynamically
-	 */
-	this.createApp = function(config) {
-		var self = this,
-			express = require('express');
-
-		//defaults
-		config = util.mixin({
-			templates : self.dir+'/theme/templates',
-			view_engine: 'jade',
-			view_options: { layout: false },
-			view_cache: false
-		}, (config||{}));
-
-		this.app = express.createServer();
-		this.app.configure(function(){
-			this.set('views', config.templates);
-			this.set('view engine', config.view_engine);
-			this.set('view options', config.view_options);
-			this.set('view cache', config.view_cache);
-			this.use(express.errorHandler({ showStack: true, dumpExceptions: true }));
-			this.use(express.bodyParser());
-			this.use(express.static(self.dir+'/theme/static'));
-			this.use(this.router);
-		});
-
-		this.plugins.forEach(function(handler) {
-			handler.register && handler.register(self);
-		});
-		return this;
-	};
-
-	/**
-	 * Load article data into memory
-	 */
-	this.load = function(articles, cb) {
-		console.log('Article Path: ' + articles.charAt(0) !== '/' ? path.join(this.dir, articles) : articles);
-		this.api.load(
-			articles.charAt(0) !== '/' ? path.join(this.dir, articles) : articles,
-			cb.bind(this)
-		);
-	};
-
-	/**
-	 * Create static version of blog in specified directory
-	 */
-	this.generate = function(dir) {
-		var self = this;
-
-		this.info('Generating:\t\t', dir);
-
-		if(require('path').existsSync(dir)) {
-			require('wrench').rmdirSyncRecursive(dir);
-			this.info('Removed directory:\t', dir);
-		}
-		fs.mkdirSync(dir);
-		this.info('Created directory:\t', dir);
-		this.plugins.forEach(function(handler) {
-			handler.generate(self, dir);
-		});
-	};
-
-	/**
-	 * Pass-thru
-	 */
-	this.listen = function(port) {
-		this.app.listen(port);
-		this.info("http server listening.", { port : port } );
-		return this;
-	};
-
-};
-
-module.exports = new Blog();
+module.exports = createBlog();

--- a/lib/plugins/archive.js
+++ b/lib/plugins/archive.js
@@ -3,11 +3,10 @@ var path = require('path'),
 
 function getTemplateData(blog) {
 	return {
+		blog: blog,
 		recent_articles : blog.api.getRecent(),
 		articles : blog.api.getAll(),
 		pageTitle : 'archive - ' + blog.title,
-		blogTitle : blog.title,
-		blogDescription : blog.description,
 		keywords : blog.keywords
 	};
 }
@@ -15,15 +14,18 @@ function getTemplateData(blog) {
 module.exports = {
 
 	register : function(blog) {
-		blog.app.get('/archive/', function(req, res) {
+		blog.app.get(blog.routes.archive, function(req, res) {
 			blog.info('serving archive');
 			res.render('archive', getTemplateData(blog));
 		});
 	},
 
 	generate : function(blog, dir) {
+		var routePath = blog.routes.archive,
+			routeFile = !path.extname(routePath) ? 'index.html' : '';
+
 		handler.createHtmlFile(
-			require('path').join(dir, 'archive', 'index.html'),
+			path.join(dir, routePath, routeFile),
 			path.join(blog.dir, 'theme', 'templates', 'archive.jade'),
 			getTemplateData(blog)
 		);

--- a/lib/plugins/article.js
+++ b/lib/plugins/article.js
@@ -3,11 +3,10 @@ var path = require('path'),
 
 function getTemplateData(blog, article) {
 	return {
+		blog: blog,
 		recent_articles : blog.api.getRecent(),
 		article : article,
 		pageTitle : article.title,
-		blogTitle : blog.title,
-		blogDescription : blog.description,
 		keywords : article.tags.join()
 	};
 }
@@ -15,8 +14,11 @@ function getTemplateData(blog, article) {
 module.exports = {
 
 	register : function(blog) {
-		blog.app.get(/^\/(\d){4}\/(\d){2}\/(\d){2}\/(.+)\/$/, function(req, res) {
-			var article = blog.api.get(req.params[3]);
+		if(!/:slug/.test(blog.routes.article)) throw new Error('must include :slug param in tag route');
+
+		blog.app.get(blog.routes.article, function(req, res) {
+			var article = blog.api.get(req.param('slug'));
+
 			blog.info('serving article: ', article.title);
 			if(article && article.publish) {
 				res.render('article', getTemplateData(blog, article));
@@ -30,10 +32,15 @@ module.exports = {
 	},
 
 	generate : function(blog, dir) {
+		if(!/slug/.test(blog.routes.article)) throw new Error('must include slug param in tag route');
+
 		blog.api.getAll().forEach(function(article) {
 			if(article.publish) {
+				var routePath = article.path,
+					routeFile = !path.extname(routePath) ? 'index.html' : '';
+
 				handler.createHtmlFile(
-					path.join(dir, article.path, 'index.html'),
+					path.join(dir, routePath, routeFile),
 					path.join(blog.dir, 'theme', 'templates', 'article.jade'),
 					getTemplateData(blog, article)
 				);

--- a/lib/plugins/error.js
+++ b/lib/plugins/error.js
@@ -3,10 +3,9 @@ var path = require('path'),
 
 function getTemplateData(blog) {
 	return {
+		blog: blog,
 		recent_articles : blog.api.getRecent(),
 		pageTitle : blog.title,
-		blogTitle : blog.title,
-		blogDescription : blog.description,
 		keywords : blog.keywords
 	};
 }
@@ -14,8 +13,11 @@ function getTemplateData(blog) {
 module.exports = {
 
 	generate : function(blog, dir) {
+		var routePath = blog.routes.error,
+			routeFile = !path.extname(routePath) ? 'index.html' : '';
+
 		handler.createHtmlFile(
-			path.join(dir, '404.html'),
+			path.join(dir, routePath, routeFile),
 			path.join(blog.dir, 'theme', 'templates', '404.jade'),
 			getTemplateData(blog)
 		);

--- a/lib/plugins/feed.js
+++ b/lib/plugins/feed.js
@@ -3,9 +3,9 @@ var path = require('path'),
 
 function getTemplateData(blog) {
 	return {
+		blog : blog,
 		articles : blog.api.getAll(),
 		blogTitle : blog.title,
-		blogDescription : blog.description,
 		domain : blog.domain
 	};
 }
@@ -13,7 +13,7 @@ function getTemplateData(blog) {
 module.exports = {
 
 	register : function(blog) {
-		blog.app.get('/feed/rss.xml', function(req, res) {
+		blog.app.get(blog.routes.feed, function(req, res) {
 			blog.info('serving feed');
 			res.contentType('application/xml');
 			res.render('feed', getTemplateData(blog));
@@ -21,8 +21,11 @@ module.exports = {
 	},
 
 	generate : function(blog, dir) {
+		var routePath = blog.routes.feed,
+			routeFile = !path.extname(routePath) ? 'rss.xml' : '';
+
 		handler.createHtmlFile(
-			path.join(dir, 'feed', 'rss.xml'),
+			path.join(dir, routePath, routeFile),
 			path.join(blog.dir, 'theme', 'templates', 'feed.jade'),
 			getTemplateData(blog)
 		);

--- a/lib/plugins/homepage.js
+++ b/lib/plugins/homepage.js
@@ -3,11 +3,10 @@ var path = require('path'),
 
 function getTemplateData(blog) {
 	return {
+		blog: blog,
 		articles : blog.api.getRecent(10),
 		recent_articles : blog.api.getRecent(),
 		pageTitle : blog.title,
-		blogTitle : blog.title,
-		blogDescription : blog.description,
 		keywords : blog.keywords
 	};
 }
@@ -15,15 +14,18 @@ function getTemplateData(blog) {
 module.exports = {
 
 	register : function(blog) {
-		blog.app.get('/', function(req, res) {
+		blog.app.get(blog.routes.homepage, function(req, res) {
 			blog.info('serving homepage');
 			res.render('homepage', getTemplateData(blog));
 		});
 	},
 
 	generate : function(blog, dir) {
+		var routePath = blog.routes.homepage,
+			routeFile = !path.extname(routePath) ? 'index.html' : '';
+
 		handler.createHtmlFile(
-			path.join(dir, 'index.html'),
+			path.join(dir, routePath, routeFile),
 			path.join(blog.dir, 'theme', 'templates', 'homepage.jade'),
 			getTemplateData(blog)
 		);

--- a/lib/plugins/tag.js
+++ b/lib/plugins/tag.js
@@ -3,12 +3,11 @@ var path = require('path'),
 
 function getTemplateData(blog, tag) {
 	return {
+		blog: blog,
 		articles : blog.api.getByTag(tag),
 		recent_articles : blog.api.getRecent(),
 		tag : tag,
 		pageTitle : tag + ' - ' + blog.title,
-		blogTitle : blog.title,
-		blogDescription : blog.description,
 		keywords : blog.keywords
 	};
 }
@@ -16,7 +15,9 @@ function getTemplateData(blog, tag) {
 module.exports = {
 
 	register : function(blog) {
-		blog.app.get('/tag/:tag/', function(req, res) {
+		if(!/:tag/.test(blog.routes.tag)) throw new Error('must include :tag param in tag route');
+
+		blog.app.get(blog.routes.tag, function(req, res) {
 			var tag = req.param('tag');
 			blog.info('serving tag: ', tag);
 			res.render('tag', getTemplateData(blog, tag));
@@ -24,9 +25,14 @@ module.exports = {
 	},
 
 	generate : function(blog, dir) {
+		if(!/:tag/.test(blog.routes.tag)) throw new Error('must include :tag param in tag route');
+
+		var routePath = blog.routes.tag,
+			routeFile = !path.extname(routePath) ? 'index.html' : '';
+
 		Object.keys(blog.api.getTags()).forEach(function(tag) {
 			handler.createHtmlFile(
-				path.join(dir, 'tag', tag, 'index.html'),
+				path.join(dir, routePath.replace(':tag', tag), routeFile),
 				path.join(blog.dir, 'theme', 'templates', 'tag.jade'),
 				getTemplateData(blog, tag)
 			);

--- a/lib/theme/templates/article-meta.jade
+++ b/lib/theme/templates/article-meta.jade
@@ -3,7 +3,7 @@ div.meta
 	ul.tags
 		each tag in article.tags
 			li
-				a(href="/tag/"+tag+"/") #{tag}
+				a(href=blog.routes.tag.replace(':tag', tag)) #{tag}
 
 	if article.author.gravatar
 		img(src="http://www.gravatar.com/avatar/"+article.author.gravatar_hash+"?s=30.jpg", width="30", height="30")

--- a/lib/theme/templates/feed.jade
+++ b/lib/theme/templates/feed.jade
@@ -2,7 +2,7 @@
 !{xml}
 rss(version="2.0")
 	channel
-		title #{blogTitle}
+		title #{blog.title}
 		link(href=domain)
 		author
 			name Brad Harris

--- a/lib/theme/templates/homepage.jade
+++ b/lib/theme/templates/homepage.jade
@@ -1,7 +1,7 @@
 extends layout
 
 block title
-	#{title}
+	#{blog.title}
 
 block sidebar
 

--- a/lib/theme/templates/layout.jade
+++ b/lib/theme/templates/layout.jade
@@ -7,7 +7,7 @@ html(lang="en")
 		meta(name="viewport", content="width=device-width,initial-scale=1")
 
 		link(href="/css/blog.css", rel="stylesheet")
-		link(rel="alternate", type="application/rss+xml", title=blogTitle+" » rss", href="/feed/rss.xml")
+		link(rel="alternate", type="application/rss+xml", title=blog.title+" » rss", href=blog.routes.feed)
 
 	body
 
@@ -15,8 +15,8 @@ html(lang="en")
 
 			header
 				h1
-					a(href="/") #{blogTitle}
-					small  [#{blogDescription}]
+					a(href="/") #{blog.title}
+					small  [#{blog.description}]
 
 			div#content-container
 

--- a/lib/theme/templates/sidebar.jade
+++ b/lib/theme/templates/sidebar.jade
@@ -18,6 +18,6 @@ h3 links
 
 ul
 	li
-		a(href="/archive/") archive
+		a(href=blog.routes.archive) archive
 	li
-		a(href="/feed/rss.xml") feed
+		a(href=blog.routes.feed) feed

--- a/lib/theme/templates/tag.jade
+++ b/lib/theme/templates/tag.jade
@@ -6,7 +6,7 @@ block sidebar
 
 block content
 
-	h2 Articles tagged with <i>"#{tag}"</i>
+	h2 Articles tagged with <i>"#{tag}"</i> (#{articles.length})
 
 	each article in articles
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies" : {
 		"colors" : "0.6.0-1",
-		"express" : "3.0.x",
+		"express" : "3.4.x",
 		"flatiron" : "0.1.16",
 		"highlight" : "0.2.1",
 		"jade" : "0.22.1",

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,4 +1,5 @@
-var path = require('path'),
+var fs = require('fs'),
+	path = require('path'),
 	vows = require('vows'),
 	assert = require('assert'),
 	moment = require('moment'),
@@ -21,19 +22,19 @@ vows.describe('flipflop')
 			},
 
 			'blog directory exists' : function() {
-				assert.isTrue(path.existsSync(this.lib.blogDir));
+				assert.isTrue(fs.existsSync(this.lib.blogDir));
 			},
 			'articles directory exists' : function() {
-				assert.isTrue(path.existsSync(this.lib.articlesDir));
+				assert.isTrue(fs.existsSync(this.lib.articlesDir));
 			},
 			'theme directory exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.blogDir, 'theme')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.blogDir, 'theme')));
 			},
 			'blog.json config file exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.blogDir, 'blog.json')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.blogDir, 'blog.json')));
 			},
 			'sample article exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.articlesDir, 'flipflop-ftw')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.articlesDir, 'flipflop-ftw')));
 			},
 			'blog title is correct' : function() {
 				assert.equal(this.lib.config.title, require('./artifacts/blog.json').title);
@@ -54,22 +55,22 @@ vows.describe('flipflop')
 			},
 
 			'public directory exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.blogDir, 'public')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.blogDir, 'public')));
 			},
 			'archive exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.blogDir, 'public', 'archive', 'index.html')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.blogDir, 'public', 'archive', 'index.html')));
 			},
 			'feed exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.blogDir, 'public', 'feed', 'rss.xml')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.blogDir, 'public', 'feed', 'rss.xml')));
 			},
 			'404 page exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.blogDir, 'public', '404.html')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.blogDir, 'public', '404.html')));
 			},
 			'images directory exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.blogDir, 'public', 'images')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.blogDir, 'public', 'images')));
 			},
 			'tag directory exists' : function() {
-				assert.isTrue(path.existsSync(path.join(this.lib.blogDir, 'public', 'tag')));
+				assert.isTrue(fs.existsSync(path.join(this.lib.blogDir, 'public', 'tag')));
 			},
 			'sample article exists' : function() {
 				var article = path.join(
@@ -79,7 +80,7 @@ vows.describe('flipflop')
 					'flipflop-ftw',
 					'index.html'
 				);
-				assert.isTrue(path.existsSync(article));
+				assert.isTrue(fs.existsSync(article));
 			}
 		}
 	})


### PR DESCRIPTION
Routes are now configurable via the `blog.json` file.

If you wanted to prefix your blog with **/blog/**, you can do the following:

``` javascript
"routes": {
    "archive": "/blog/archive",
    "article": "/blog/:year/:month/:day/:slug",
    "error": "/blog/404.html",
    "homepage": "/blog",
    "feed": "/blog/feed/rss.xml",
    "tag": "/blog/tag/:tag"
}
```
- **article** requires a `:slug` param in the route
- **tag** requires a `:tag` param in the route
